### PR TITLE
Refine LR tuning defaults and GPU diagnostics

### DIFF
--- a/train_gpt.py
+++ b/train_gpt.py
@@ -32,26 +32,32 @@ from torch import Tensor, nn
 dynamo.config.recompile_limit = 64
 
 
-def _flatten_params_to_cpu(params: list[Tensor]) -> Tensor:
+def _flatten_params(
+    params: list[Tensor], *, device: torch.device | str | None = None
+) -> Tensor:
     flats = []
     for p in params:
-        flats.append(p.detach().to(device="cpu", dtype=torch.float32).reshape(-1))
+        target_device = device if device is not None else p.device
+        flats.append(p.detach().to(device=target_device, dtype=torch.float32).reshape(-1))
     if flats:
         return torch.cat(flats)
-    return torch.zeros(1, dtype=torch.float32)
+    return torch.zeros(1, dtype=torch.float32, device=device or "cpu")
 
 
-def _flatten_grads_to_cpu(params: list[Tensor]) -> Tensor:
+def _flatten_grads(
+    params: list[Tensor], *, device: torch.device | str | None = None
+) -> Tensor:
     flats = []
     for p in params:
         grad = p.grad
+        target_device = device if device is not None else p.device
         if grad is None:
-            flats.append(torch.zeros(p.numel(), dtype=torch.float32))
+            flats.append(torch.zeros(p.numel(), dtype=torch.float32, device=target_device))
         else:
-            flats.append(grad.detach().to(device="cpu", dtype=torch.float32).reshape(-1))
+            flats.append(grad.detach().to(device=target_device, dtype=torch.float32).reshape(-1))
     if flats:
         return torch.cat(flats)
-    return torch.zeros(1, dtype=torch.float32)
+    return torch.zeros(1, dtype=torch.float32, device=device or "cpu")
 
 
 def _safe_norm(tensor: Tensor) -> float:
@@ -1183,7 +1189,7 @@ class Hyperparameters:
     # optimization
     num_iterations: int = 1645 # number of iterations to run
     cooldown_frac: int = 0.5 # fraction of training spent cooling down the learning rate
-    lr_tuning_steps: tuple[int, ...] = ()
+    lr_tuning_steps: tuple[int, ...] | None = None
     lr_adapt_clip_min: float = 0.5
     lr_adapt_clip_max: float = 3.0
     # evaluation and logging
@@ -1197,6 +1203,9 @@ class Hyperparameters:
     ws_validate_final_layer: int = 20 # final layer shows no degradation with context length
 
 args = Hyperparameters()
+
+if args.lr_tuning_steps is None:
+    args.lr_tuning_steps = tuple(range(125, args.num_iterations, 125))
 
 data_path = os.environ.get("DATA_PATH", ".")
 args.train_files = os.path.join(data_path, args.train_files)
@@ -1289,6 +1298,9 @@ for opt in optimizers:
     for group in opt.param_groups:
         group_names = [param_name_by_id.get(id(p), f"param_{id(p)}") for p in group["params"]]
         opt_names.append(group_names)
+        for param in group["params"]:
+            if not hasattr(param, "lr_mul"):
+                setattr(param, "lr_mul", 1.0)
     optimizer_group_param_names.append(opt_names)
 
 # learning rate schedule: stable then decay
@@ -1402,22 +1414,26 @@ for step in range(train_steps + 1):
     if diagnostic_step:
         diag_cache = []
         for opt in optimizers:
-            opt_info: list[dict[str, Tensor]] = []
+            opt_info: list[list[dict[str, Tensor]]] = []
             for group in opt.param_groups:
-                params = group["params"]
-                opt_info.append(
-                    {
-                        "pre_grad": _flatten_grads_to_cpu(params),
-                        "param_before": _flatten_params_to_cpu(params),
-                    }
-                )
+                group_cache: list[dict[str, Tensor]] = []
+                for param in group["params"]:
+                    device = param.device
+                    group_cache.append(
+                        {
+                            "pre_grad": _flatten_grads([param], device=device),
+                            "param_before": _flatten_params([param], device=device),
+                        }
+                    )
+                opt_info.append(group_cache)
             diag_cache.append(opt_info)
     # set optimization hyperparameters
     for opt in optimizers:
         for group in opt.param_groups:
             baseline_lr = group["initial_lr"] * get_lr(step)
+            group["lr_factor"] = 1.0
             group["lr_baseline"] = baseline_lr
-            group["lr"] = baseline_lr * group.get("lr_factor", 1.0)
+            group["lr"] = baseline_lr
     for group in optimizer2.param_groups:
         frac = min(step / 300, 1) # momentum warmup for muon
         group["momentum"] = (1 - frac) * 0.85 + frac * 0.95
@@ -1427,7 +1443,9 @@ for step in range(train_steps + 1):
     if diagnostic_step and diag_cache is not None:
         for opt_idx, opt in enumerate(optimizers):
             for group_idx, group in enumerate(opt.param_groups):
-                diag_cache[opt_idx][group_idx]["param_after"] = _flatten_params_to_cpu(group["params"])
+                group_cache = diag_cache[opt_idx][group_idx]
+                for param_idx, param in enumerate(group["params"]):
+                    group_cache[param_idx]["param_after"] = _flatten_params([param], device=param.device)
         model.zero_grad(set_to_none=True)
         for inputs, targets, cum_seqlens in diag_batches:
             model(inputs, targets, cum_seqlens, ws, ws_final_layer).backward()
@@ -1435,24 +1453,27 @@ for step in range(train_steps + 1):
         for opt_idx, opt in enumerate(optimizers):
             for group_idx, group in enumerate(opt.param_groups):
                 params = group["params"]
-                info = diag_cache[opt_idx][group_idx]
-                info["post_grad"] = _flatten_grads_to_cpu(params)
-                grad_delta = info["post_grad"] - info["pre_grad"]
-                param_delta = info["param_after"] - info["param_before"]
-                grad_delta_norm = _safe_norm(grad_delta)
-                param_delta_norm = _safe_norm(param_delta)
-                metric = grad_delta_norm / max(param_delta_norm, 1e-12)
-                if not math.isfinite(metric):
-                    metric = float("inf")
-                metric_entries.append(
-                    (
-                        opt_idx,
-                        group_idx,
-                        grad_delta_norm,
-                        param_delta_norm,
-                        metric,
+                group_cache = diag_cache[opt_idx][group_idx]
+                for param_idx, param in enumerate(params):
+                    info = group_cache[param_idx]
+                    info["post_grad"] = _flatten_grads([param], device=param.device)
+                    grad_delta = info["post_grad"] - info["pre_grad"]
+                    param_delta = info["param_after"] - info["param_before"]
+                    grad_delta_norm = _safe_norm(grad_delta)
+                    param_delta_norm = _safe_norm(param_delta)
+                    metric = grad_delta_norm / max(param_delta_norm, 1e-12)
+                    if not math.isfinite(metric):
+                        metric = float("inf")
+                    metric_entries.append(
+                        (
+                            opt_idx,
+                            group_idx,
+                            param_idx,
+                            grad_delta_norm,
+                            param_delta_norm,
+                            metric,
+                        )
                     )
-                )
         finite_metrics = [m for *_, m in metric_entries if math.isfinite(m)]
         if finite_metrics:
             pivot = float(torch.tensor(finite_metrics, dtype=torch.float32).median().item())
@@ -1462,7 +1483,7 @@ for step in range(train_steps + 1):
             pivot = 1.0
         clip_min = args.lr_adapt_clip_min
         clip_max = args.lr_adapt_clip_max
-        for opt_idx, group_idx, grad_delta_norm, param_delta_norm, metric in metric_entries:
+        for opt_idx, group_idx, param_idx, grad_delta_norm, param_delta_norm, metric in metric_entries:
             group = optimizers[opt_idx].param_groups[group_idx]
             if metric <= 0 or not math.isfinite(metric):
                 raw_factor = clip_max if metric <= 0 else clip_min
@@ -1471,14 +1492,12 @@ for step in range(train_steps + 1):
             if not math.isfinite(raw_factor):
                 raw_factor = 1.0
             factor = float(min(clip_max, max(clip_min, raw_factor)))
-            group["lr_factor"] = factor
-            group["lr"] = group["lr_baseline"] * factor
+            param = group["params"][param_idx]
+            setattr(param, "lr_mul", factor)
             names = optimizer_group_param_names[opt_idx][group_idx]
-            eff_lrs = [group["lr"] * getattr(param, "lr_mul", 1.0) for param in group["params"]]
-            lr_entries = ", ".join(
-                f"{name}:{lr:.6g}" for name, lr in zip(names, eff_lrs)
-            )
-            info = diag_cache[opt_idx][group_idx]
+            name = names[param_idx] if param_idx < len(names) else f"param_{param_idx}"
+            eff_lr = group["lr"] * getattr(param, "lr_mul", 1.0)
+            info = diag_cache[opt_idx][group_idx][param_idx]
 
             # Compute RMS-based diagnostics and cosine similarity
             eps = 1e-12
@@ -1489,14 +1508,14 @@ for step in range(train_steps + 1):
             dgrad = gpost - gpre
             dtheta = pafter - pbefore
 
-            def _rms_cpu(t: torch.Tensor) -> float:
+            def _rms(t: torch.Tensor) -> float:
                 n = max(1, t.numel())
                 return t.norm().item() / math.sqrt(n)
 
-            rms_dgrad = _rms_cpu(dgrad)
-            rms_dtheta = _rms_cpu(dtheta)
-            rms_gpre = _rms_cpu(gpre)
-            rms_pbefore = _rms_cpu(pbefore)
+            rms_dgrad = _rms(dgrad)
+            rms_dtheta = _rms(dtheta)
+            rms_gpre = _rms(gpre)
+            rms_pbefore = _rms(pbefore)
 
             lhat = rms_dgrad / (rms_dtheta + eps)              # gradient change per unit parameter move
             rho = rms_dgrad / (rms_gpre + eps)                 # relative grad change
@@ -1505,10 +1524,10 @@ for step in range(train_steps + 1):
             cosine = float(torch.dot(gpre, gpost).item() / (denom + eps))
 
             log_msg = (
-                f"lr_tune step:{step} opt:{opt_idx} group:{group_idx} metric:{metric:.6g} "
+                f"lr_tune step:{step} opt:{opt_idx} group:{group_idx} param:{param_idx} name:{name} metric:{metric:.6g} "
                 f"grad_pre:{_safe_norm(info['pre_grad']):.6g} grad_post:{_safe_norm(info['post_grad']):.6g} "
                 f"grad_delta:{grad_delta_norm:.6g} param_delta:{param_delta_norm:.6g} "
-                f"factor:{factor:.6g} baseline_lr:{group['lr_baseline']:.6g} lrs:[{lr_entries}] "
+                f"factor:{factor:.6g} baseline_lr:{group['lr_baseline']:.6g} eff_lr:{eff_lr:.6g} "
                 f"lhat:{lhat:.6g} rho:{rho:.6g} utr:{utr:.6g} cos:{cosine:.6g}"
             )
             print0(log_msg)


### PR DESCRIPTION
## Summary
- default lr tuning steps to every 125 iterations when unspecified
- capture diagnostic snapshots per-parameter on GPU to enable granular learning rate factors
- apply per-parameter multipliers while keeping optimizer steps efficient and log richer metrics

## Testing
- python -m compileall train_gpt.py

------
https://chatgpt.com/codex/tasks/task_e_68cea44840dc8333971bca89493d3ee6